### PR TITLE
[WIP] add import export modules

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -66,6 +66,7 @@ pip install -r requirements/requirements.txt -r requirements/requirements_dev.tx
 make clean-api
 pip install -e <path to your Ansible>
 pip install -e .
+pip install -e awxkit
 py.test awx_collection/test/awx/
 ```
 

--- a/awx_collection/plugins/modules/tower_export.py
+++ b/awx_collection/plugins/modules/tower_export.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2017, John Westcott IV <john.westcott.iv@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: tower_export
+author: "Jeff Bradberry (@jbradberry)"
+version_added: "3.7"
+short_description: export resources from Ansible Tower.
+description:
+    - Export assets from Ansible Tower.
+options:
+    all:
+      description:
+        - Export all assets
+      type: bool
+      default: 'False'
+    organizations:
+      description:
+        - organization name to export
+      default: ''
+      type: str
+    user:
+      description:
+        - user name to export
+      default: ''
+      type: str
+    team:
+      description:
+        - team name to export
+      default: ''
+      type: str
+    credential_type:
+      description:
+        - credential type name to export
+      default: ''
+      type: str
+    credential:
+      description:
+        - credential name to export
+      default: ''
+      type: str
+    notification_template:
+      description:
+        - notification template name to export
+      default: ''
+      type: str
+    inventory_script:
+      description:
+        - inventory script name to export
+      default: ''
+      type: str
+    inventory:
+      description:
+        - inventory name to export
+      default: ''
+      type: str
+    project:
+      description:
+        - project name to export
+      default: ''
+      type: str
+    job_template:
+      description:
+        - job template name to export
+      default: ''
+      type: str
+    workflow:
+      description:
+        - workflow name to export
+      default: ''
+      type: str
+
+requirements:
+  - "awxkit >= 9.3.0"
+
+notes:
+  - Specifying a name of "all" for any asset type will export all items of that asset type.
+
+extends_documentation_fragment: awx.awx.auth
+'''
+
+EXAMPLES = '''
+- name: Export all tower assets
+  tower_export:
+    all: True
+
+- name: Export all inventories
+  tower_export:
+    inventory: ''
+
+- name: Export a job template named "My Template" and all Credentials
+  tower_export:
+    job_template: "My Template"
+    credential: ''
+'''
+
+from os import environ
+
+from ..module_utils.ansible_tower import TowerModule
+
+try:
+    import awxkit
+except ImportError:
+    HAS_AWXKIT = False
+else:
+    HAS_AWXKIT = True
+    from awxkit import config
+    from awxkit.api import get_registered_page
+    from awxkit.api.client import Connection
+    from awxkit.cli.resource import Export
+    from awxkit.awx.utils import as_user
+
+
+def main():
+    argument_spec = dict(
+        all=dict(type='bool', default=False),
+        credentials=dict(default=''),
+        credential_types=dict(default=''),
+        inventories=dict(default=''),
+        inventory_scripts=dict(default=''),
+        job_templates=dict(default=''),
+        notification_templates=dict(default=''),
+        organizations=dict(default=''),
+        projects=dict(default=''),
+        teams=dict(default=''),
+        users=dict(default=''),
+        workflows=dict(default=''),
+    )
+
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    if not HAS_AWXKIT:
+        module.fail_json(msg='awxkit required for this module')
+
+    EXPORT_ORDER = [
+        'users',
+        'organizations',
+        'teams',
+        'credentials'
+    ]
+
+    export_all = module.params.get('all')
+    assets_to_export = []
+    for asset_type in EXPORT_ORDER:
+        if export_all or module.params.get(asset_type) == '':
+            assets_to_export.append((asset_type, ''))
+        else:
+            assets_to_export.append((asset_type, module.params.get(asset_type)))
+
+    result = dict(
+        assets=None,
+        changed=False,
+        message='',
+    )
+
+    config_params = [
+        ('base_url', 'tower_host', 'TOWER_HOST'),
+        ('token', 'tower_oauthtoken', 'TOWER_TOKEN'),
+        ('username', 'tower_username', 'TOWER_USERNAME'),
+        ('password', 'tower_password', 'TOWER_PASSWORD'),
+        ('insecure', 'validate_certs', 'TOWER_VERIFY_SSL')
+    ]
+    for key, param, env_var in config_params:
+        val = None
+        if module.params.get(param):
+            val = module.params.get(param)
+        elif environ.get(env_var):
+            val = environ.get(env_var)
+
+        if key == 'insecure':
+            val = bool(not val)
+
+        if val is not None:
+            setattr(config, key, val)
+
+    connection = Connection(config.base_url, verify=not config.insecure)
+    with as_user(connection, config.username, config.password):
+        v2 = get_registered_page('/api/v2/')(connection).get()
+        exporter = Export()
+        exporter.v2 = v2
+        assets = exporter.perform_export(assets_to_export)
+        result['assets'] = assets
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/awx_collection/plugins/modules/tower_import.py
+++ b/awx_collection/plugins/modules/tower_import.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2017, John Westcott IV <john.westcott.iv@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: tower_import
+author: "Jeff Bradberry (@jbradberry)"
+version_added: "3.7"
+short_description: import resources into Ansible Tower.
+description:
+    - Import assets into Ansible Tower. See
+      U(https://www.ansible.com/tower) for an overview.
+options:
+    assets:
+      description:
+        - The assets to import.
+        - This can be the output of tower_export or loaded from a file
+      required: True
+      type: dict
+
+notes:
+  - One of assets or files needs to be passed in
+
+requirements:
+  - "awxkit >= 9.3.0"
+
+extends_documentation_fragment: awx.awx.auth
+'''
+
+EXAMPLES = '''
+- name: Import all tower assets
+  tower_import:
+    assets: "{{ export_output.assets }}"
+'''
+
+import os
+import sys
+
+from ..module_utils.ansible_tower import TowerModule
+
+try:
+    import awxkit
+except ImportError:
+    HAS_AWXKIT = False
+else:
+    HAS_AWXKIT = True
+    from awxkit.cli.resource import Import
+
+
+def main():
+    argument_spec = dict(
+        assets=dict(required=False)
+    )
+
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    assets = module.params.get('assets')
+
+    if not HAS_AWXKIT:
+        module.fail_json(msg='towerkit required for this module')
+
+    Import().perform_import(assets)
+
+    if not TOWER_CLI_HAS_EXPORT:
+        module.fail_json(msg='ansible-tower-cli version does not support export')
+
+    result = dict(
+        changed=False,
+        msg='',
+        output='',
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -78,6 +78,7 @@ def run_module(request, collection_import):
         def new_request(self, method, url, **kwargs):
             kwargs_copy = kwargs.copy()
             if 'data' in kwargs:
+                print(kwargs)
                 if not isinstance(kwargs['data'], dict):
                     kwargs_copy['data'] = json.loads(kwargs['data'])
                 else:

--- a/awx_collection/test/awx/test_export_import.py
+++ b/awx_collection/test/awx/test_export_import.py
@@ -1,0 +1,78 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from unittest import mock
+import json
+
+from awx.main.models import (
+    Organization,
+    Project,
+    Inventory,
+    Host,
+    CredentialType,
+    Credential,
+    JobTemplate
+)
+
+
+@pytest.mark.django_db
+def test_export_import_jt(run_module, admin_user, mocker):
+    org = Organization.objects.create(name='SRtest')
+    proj = Project.objects.create(
+        name='SRtest',
+        playbook_files=['debug.yml'],
+        scm_type='git',
+        scm_url='https://github.com/ansible/test-playbooks.git',
+        organization=org,
+        allow_override=True  # so we do not require playbooks populated
+    )
+    inv = Inventory.objects.create(name='SRtest', organization=org)
+    Host.objects.create(name='SRtest', inventory=inv)
+    ct = CredentialType.defaults['ssh']()
+    ct.save()
+    cred = Credential.objects.create(
+        name='SRtest',
+        credential_type=ct,
+        organization=org
+    )
+    jt = JobTemplate.objects.create(
+        name='SRtest',
+        project=proj,
+        inventory=inv,
+        playbook='helloworld.yml'
+    )
+    jt.credentials.add(cred)
+    jt.admin_role.members.add(admin_user)  # work around send/receive bug
+
+    # receive everything
+    result = run_module('tower_export', dict(all=True), admin_user)
+
+    assert 'assets' in result, result
+    assets = result['assets']
+    assert not result.get('changed', True)
+    assert set(a['asset_type'] for a in assets) == set((
+        'organization', 'inventory', 'job_template', 'credential', 'project',
+        'user'
+    ))
+
+    # delete everything
+    for obj in (jt, inv, proj, cred, org):
+        obj.delete()
+
+    def fake_wait(self, pk, parent_pk=None, **kwargs):
+        return {"changed": True}
+
+    # recreate everything
+    with mocker.patch('sys.stdin.isatty', return_value=True):
+        with mocker.patch('tower_cli.models.base.MonitorableResource.wait'):  # REPLACE
+            # warns based on password_management param, but not security issue
+            with mock.patch('ansible.module_utils.basic.AnsibleModule.warn'):
+                result = run_module('tower_import', {"assets": assets}, admin_user)
+
+    assert not result.get('failed'), result
+
+    new = JobTemplate.objects.get(name='SRtest')
+    assert new.project.name == 'SRtest'
+    assert new.inventory.name == 'SRtest'
+    assert [cred.name for cred in new.credentials.all()] == ['SRtest']

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -51,7 +51,7 @@ EXPORTABLE_RESOURCES = [
     'users',
     'organizations',
     'teams',
-    # 'credential_types',
+    'credential_types',
     # 'credentials',
     # 'notification_templates',
     # 'projects',
@@ -316,9 +316,14 @@ class Export(CustomCommand):
             results = endpoint.get(all_pages=True).results
 
         options = self.get_options(endpoint)
-        return [self.serialize_asset(asset, options) for asset in results]
+        assets = (self.serialize_asset(asset, options) for asset in results)
+        return [asset for asset in assets if asset is not None]
 
     def serialize_asset(self, asset, options):
+        # Drop any (credential_type) assets that are being managed by the Tower instance.
+        if asset.json.get('managed_by_tower'):
+            return None
+
         fields = {
             key: asset[key] for key in options
             if key in asset.json and key not in asset.related

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -123,6 +123,41 @@ class Config(CustomCommand):
         }
 
 
+class Export(CustomCommand):
+    name = 'export'
+    help_text = 'export resources from Tower as yaml'
+
+    def extend_parser(self, parser):
+        resources = parser.add_argument_group('resources')
+        resources.add_argument('--users', nargs='?', const='')
+
+    def handle(self, client, parser):
+        self.extend_parser(parser)
+
+        if client.help:
+            parser.print_help()
+            raise SystemExit()
+
+        parsed = parser.parse_known_args()[0]
+
+        data = {}
+        for resource in ('users',):
+            value = getattr(parsed, resource, None)
+            if value is None:
+                print("Pulling no users.")
+                continue
+            if value:
+                print("Pulling users: {}".format(value))
+                pass
+            else:
+                print("Pulling all users.")
+                pass
+
+            data[resource] = {}
+
+        return data
+
+
 def parse_resource(client, skip_deprecated=False):
     subparsers = client.parser.add_subparsers(
         dest='resource',

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -132,12 +132,14 @@ class Export(CustomCommand):
         resources.add_argument('--users', nargs='?', const='')
 
     def get_resources(self, client, resource, value):
+        api_resource = getattr(client.v2, resource)
         if value:
             from .options import pk_or_name
 
-            print("Pulling {}: {}".format(resource, pk_or_name(client.v2, resource, value)))
+            pk = pk_or_name(client.v2, resource, value)
+            return api_resource.get(id=pk).json['results']
         else:
-            print("Pulling all {}.".format(resource))
+            return api_resource.get(all_pages=True).json['results']
 
     def handle(self, client, parser):
         self.extend_parser(parser)
@@ -153,11 +155,10 @@ class Export(CustomCommand):
         for resource in ('users',):
             value = getattr(parsed, resource, None)
             if value is None:
-                print("Pulling no {}.".format(resource))
                 continue
-            self.get_resources(client, resource, value)
+            resources = self.get_resources(client, resource, value) or []
 
-            data[resource] = {}
+            data[resource] = resources
 
         return data
 

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -329,7 +329,10 @@ class Export(CustomCommand):
                 related[k] = [get_natural_key(x) for x in data.results]
 
         related_fields = {'related': related} if related else {}
-        return dict(**fields, **fk_fields, **related_fields)
+
+        fields.update(fk_fields)
+        fields.update(related_fields)
+        return fields
 
     def handle(self, client, parser):
         self.extend_parser(parser)

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -225,20 +225,20 @@ class Export(CustomCommand):
 
     def serialize_asset(self, asset, options):
         fields = {
-            key: asset.json[key] for key in options
-            if key in asset.json and options[key]['type'] != 'id'
+            key: asset[key] for key in options
+            if key in asset.json and key not in asset.related
         }
 
         fk_fields = {
             key: self.get_natural_key(asset.related[key].get()) for key in options
-            if key in asset.json and options[key]['type'] == 'id'
+            if key in asset.related
         }
 
         related = {}
         for k, related_endpoint in asset.related.items():
             if k != 'roles':
                 continue
-            data = related_endpoint.get(all_pages=True).json
+            data = related_endpoint.get(all_pages=True)
             if 'results' in data:
                 related[k] = [self.get_natural_key(x) for x in data.results]
 

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -4,7 +4,7 @@ import sys
 
 from awxkit import api, config
 from awxkit.utils import to_str
-from awxkit.api.pages import Page, TentativePage
+from awxkit.api.pages import Page
 from awxkit.cli.format import FORMATTERS, format_response, add_authentication_arguments
 from awxkit.cli.utils import CustomRegistryMeta, cprint
 
@@ -75,8 +75,8 @@ NATURAL_KEYS = {
 
 
 def get_natural_key(page):
-    natural_key = {'type': page.type}
-    lookup = NATURAL_KEYS.get(page.type, ())
+    natural_key = {'type': page['type']}
+    lookup = NATURAL_KEYS.get(page['type'], ())
 
     for key in lookup or ():
         if key.startswith(':'):
@@ -236,6 +236,7 @@ class Export(CustomCommand):
             key: asset[key] for key in options
             if key in asset.json and key not in asset.related
         }
+        fields['natural_key'] = get_natural_key(asset)
 
         fk_fields = {
             key: get_natural_key(asset.related[key].get()) for key in options

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -201,8 +201,6 @@ class Import(CustomCommand):
         options = self._options[resource]
         for asset in assets:
             post_data = {}
-            if resource == 'users' and 'password' not in asset:
-                post_data['password'] = 'password'
             for field, value in asset.items():
                 if field in ('related', 'natural_key'):
                     continue
@@ -213,6 +211,9 @@ class Import(CustomCommand):
 
             page = self.get_by_natural_key(asset['natural_key'], fetch=False)
             if page is None:
+                if resource == 'users':
+                    # We should only impose a default password if the resource doesn't exist.
+                    post_data.setdefault('password', 'password')
                 page = endpoint.post(post_data)
             else:
                 page = page.put(post_data)

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -133,13 +133,16 @@ class Export(CustomCommand):
 
     def get_resources(self, client, resource, value):
         api_resource = getattr(client.v2, resource)
+        post_fields = api_resource.options().json['actions']['POST']
         if value:
             from .options import pk_or_name
 
             pk = pk_or_name(client.v2, resource, value)
-            return api_resource.get(id=pk).json['results']
+            results = api_resource.get(id=pk).json['results']
         else:
-            return api_resource.get(all_pages=True).json['results']
+            results = api_resource.get(all_pages=True).json['results']
+
+        return [{key: r[key] for key in post_fields if key in r} for r in results]
 
     def handle(self, client, parser):
         self.extend_parser(parser)
@@ -156,7 +159,7 @@ class Export(CustomCommand):
             value = getattr(parsed, resource, None)
             if value is None:
                 continue
-            resources = self.get_resources(client, resource, value) or []
+            resources = self.get_resources(client, resource, value)
 
             data[resource] = resources
 

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -51,13 +51,13 @@ EXPORTABLE_RESOURCES = [
     'users',
     'organizations',
     'teams',
-    'credential_types',
-    'credentials',
-    'notification_templates',
-    'projects',
-    'inventory',
-    'job_templates',
-    'workflow_job_templates',
+    # 'credential_types',
+    # 'credentials',
+    # 'notification_templates',
+    # 'projects',
+    # 'inventory',
+    # 'job_templates',
+    # 'workflow_job_templates',
 ]
 
 NATURAL_KEYS = {

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -52,7 +52,7 @@ EXPORTABLE_RESOURCES = [
     'organizations',
     'teams',
     'credential_types',
-    # 'credentials',
+    'credentials',
     # 'notification_templates',
     # 'projects',
     # 'inventory',

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -131,6 +131,14 @@ class Export(CustomCommand):
         resources = parser.add_argument_group('resources')
         resources.add_argument('--users', nargs='?', const='')
 
+    def get_resources(self, client, resource, value):
+        if value:
+            from .options import pk_or_name
+
+            print("Pulling {}: {}".format(resource, pk_or_name(client.v2, resource, value)))
+        else:
+            print("Pulling all {}.".format(resource))
+
     def handle(self, client, parser):
         self.extend_parser(parser)
 
@@ -138,20 +146,16 @@ class Export(CustomCommand):
             parser.print_help()
             raise SystemExit()
 
+        client.authenticate()
         parsed = parser.parse_known_args()[0]
 
         data = {}
         for resource in ('users',):
             value = getattr(parsed, resource, None)
             if value is None:
-                print("Pulling no users.")
+                print("Pulling no {}.".format(resource))
                 continue
-            if value:
-                print("Pulling users: {}".format(value))
-                pass
-            else:
-                print("Pulling all users.")
-                pass
+            self.get_resources(client, resource, value)
 
             data[resource] = {}
 

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -53,7 +53,7 @@ EXPORTABLE_RESOURCES = [
     'teams',
     'credential_types',
     'credentials',
-    # 'notification_templates',
+    'notification_templates',
     # 'projects',
     # 'inventory',
     # 'job_templates',

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -157,6 +157,7 @@ class Export(CustomCommand):
     def extend_parser(self, parser):
         resources = parser.add_argument_group('resources')
         resources.add_argument('--users', nargs='?', const='')
+        resources.add_argument('--organizations', nargs='?', const='')
 
     def get_resources(self, client, resource, value):
         api_resource = getattr(client.v2, resource)
@@ -182,7 +183,7 @@ class Export(CustomCommand):
         parsed = parser.parse_known_args()[0]
 
         data = {}
-        for resource in ('users',):
+        for resource in ('users', 'organizations'):
             value = getattr(parsed, resource, None)
             if value is None:
                 continue

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -291,7 +291,9 @@ class Import(CustomCommand):
         client.authenticate()
         self.client = client
         self.v2 = client.v2
+        self.perform_import(client)
 
+    def perform_import(self, data):
         for resource in self.dependent_resources(data):
             self.register_existing_assets(resource)
             self.create_assets(data, resource)
@@ -376,14 +378,21 @@ class Export(CustomCommand):
 
         # If no resource flags are explicitly used, export everything.
         all_resources = all(getattr(parsed, resource, None) is None for resource in EXPORTABLE_RESOURCES)
-
-        self.v2 = client.v2
-
-        data = {}
+        export_list = []
         for resource in EXPORTABLE_RESOURCES:
             value = getattr(parsed, resource, None)
             if all_resources or value is not None:
-                data[resource] = self.get_assets(resource, value)
+                export_list.append((resource, value))
+
+        self.v2 = client.v2
+        data = self.perform_export(export_list)
+
+        return data
+
+    def perform_export(self, export_list):
+        data = {}
+        for resource, value in export_list:
+            data[resource] = self.get_assets(resource, value)
 
         return data
 


### PR DESCRIPTION
##### SUMMARY
I got as far as getting it to give the same error

```yaml
---
- hosts: localhost
  gather_facts: false
  connection: local
  collections:
    - awx.awx
  tasks:
  # - name: Export demo stuff
  #   tower_receive:
  #     job_template:
  #       - "Demo Job Template"
  #   register: result
  # 
  # - debug: var=result

  - name: New export
    tower_export:
      users: admin
```

gives

```
(awx_collection) arominge-OSX:tower alancoding$ ansible-playbook sanity/receive.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ********************************************************************************************************************************************************************

TASK [New export] *******************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: awxkit.exceptions.Unauthorized: Unauthorized (401) received - {'detail': 'Authentication credentials were not provided. To establish a login session, visit /api/login/.'}
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/Users/alancoding/.ansible/tmp/ansible-tmp-1584648157.6257222-61154841635331/AnsiballZ_tower_export.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/Users/alancoding/.ansible/tmp/ansible-tmp-1584648157.6257222-61154841635331/AnsiballZ_tower_export.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/alancoding/.ansible/tmp/ansible-tmp-1584648157.6257222-61154841635331/AnsiballZ_tower_export.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.awx.awx.plugins.modules.tower_export', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/var/folders/fj/6z5pn3wj5w31zvn2pws34svm0000gn/T/ansible_tower_export_payload_45c89fqm/ansible_tower_export_payload.zip/ansible_collections/awx/awx/plugins/modules/tower_export.py\", line 200, in <module>\n  File \"/var/folders/fj/6z5pn3wj5w31zvn2pws34svm0000gn/T/ansible_tower_export_payload_45c89fqm/ansible_tower_export_payload.zip/ansible_collections/awx/awx/plugins/modules/tower_export.py\", line 193, in main\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 395, in perform_export\n    data[resource] = self.get_assets(resource, value)\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 337, in get_assets\n    return [asset for asset in assets if asset is not None]\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 337, in <listcomp>\n    return [asset for asset in assets if asset is not None]\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 336, in <genexpr>\n    assets = (self.serialize_asset(asset, options) for asset in results)\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 361, in serialize_asset\n    related[k] = [get_natural_key(x) for x in data.results]\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 361, in <listcomp>\n    related[k] = [get_natural_key(x) for x in data.results]\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/cli/resource.py\", line 92, in get_natural_key\n    natural_key[key[1:]] = get_natural_key(related_objs[0].get())\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py\", line 396, in get\n    return self._create().get(**params)\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py\", line 275, in get\n    page = self.page_identity(r)\n  File \"/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py\", line 210, in page_identity\n    raise exception(exc_str, data)\nawxkit.exceptions.Unauthorized: Unauthorized (401) received - {'detail': 'Authentication credentials were not provided. To establish a login session, visit /api/login/.'}\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP **************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

so that looks similar to:

```
    specify an output format
  --filter TEXT         specify an output filter (only valid with jq or human
                        format)
  --conf.color BOOLEAN  Display colorized output. Defaults to True
  -v, --verbose         print debug-level logs, including requests made

Valid credentials were not provided.
$ awx login --help

<class 'awxkit.exceptions.Unauthorized'>
```